### PR TITLE
Added option to ignore errors reported from tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Put a `.checkbuild` file ([example](./defaults/.checkbuild)) in your project roo
 ```json
 {
   "checkbuild": {
-    "enable": ["jshint", "jscs", "jsinspect", "buddyjs", "nsp"]
+    "enable": ["jshint", "jscs", "jsinspect", "buddyjs", "nsp"],
+    "continueOnError": true  // don't exit immediately if one of the tools reports an error
   },
 
   "jshint": {

--- a/check-build.js
+++ b/check-build.js
@@ -53,7 +53,7 @@ async.forEachSeries(
     // execute module interface
     console.log('[%s]', name);
     module(checkbuildOptions[name], function (err) {
-      if (err) {
+      if (err && ! checkbuildOptions.checkbuild.continueOnError) {
         console.error('Checkbuild module "%s" failed, exiting.', name);
         console.error(err);
         return process.exit(1);


### PR DESCRIPTION
add the following to `.checkbuild` to continue if one tool reports an error:

``` json
{
  "checkbuild" : {
    "continueOnError" : true
  }
}
```
