### PR TITLE
Remove syntax errors from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ echo $?
 
 Put a `.checkbuild` file ([example](./defaults/.checkbuild)) in your project root directory.
 
-```json
+```javascript
 {
   "checkbuild": {
     "enable": ["jshint", "jscs", "jsinspect", "nsp", "david"],


### PR DESCRIPTION
Set JSON example syntax to JS. Comments are not allowed in JSON and are highlighted as errors.
