### PR TITLE
Add support for JSON5

### DIFF
--- a/check-build.js
+++ b/check-build.js
@@ -2,10 +2,10 @@
 
 'use strict';
 
+var JSON5 = require('json5');
 var p = require('path');
 var shjs = require("shelljs");
 var async = require("async");
-var stripJsonComments = require('strip-json-comments');
 var checkbuildContent, checkbuildOptions;
 
 var checkbuildFile = [
@@ -30,7 +30,7 @@ if (!checkbuildContent) {
 }
 
 try {
-  checkbuildOptions = JSON.parse(stripJsonComments(checkbuildContent));
+  checkbuildOptions = JSON5.parse(checkbuildContent);
 } catch (err) {
   console.error('Invalid json content inside `.checkbuild`');
   console.error(err);

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "jshint": "^2.5.6",
     "jshint-stylish": "^1.0.0",
     "jsinspect": "^0.2.0",
+    "json5": "^0.4.0",
     "lodash": "^2.4.1",
     "node-filepaths": "0.0.2",
     "nsp": "^0.4.2",
-    "shelljs": "^0.3.0",
-    "strip-json-comments": "^1.0.2"
+    "shelljs": "^0.3.0"
   }
 }


### PR DESCRIPTION
JSON5 is an extension to JSON that makes it easier to write JSON files.
One example is the ability to use comments inside JSON files.

You can read more about JSON5 on [npm](https://www.npmjs.org/package/json5).
