### PR TITLE
Updating JSCS version to 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-react": "^3.2.3",
     "fixmyjs": "^1.0.2",
     "grunt": "^0.4.5",
-    "jscs": "1.x.x",
+    "jscs": "3.x.x",
     "jshint": "^2.5.6",
     "jshint-stylish": "2.0.1",
     "jsinspect": "0.x.x",


### PR DESCRIPTION
I updated JSCS to version 3.0

Warning : Every project with an outdated .jscsrc containing « esnext » option will not pass check-build anymore.