### PR TITLE
Add unresolved dependency to snyk-resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "plato": "^1.5.0",
     "requestretry": "^1.2.2",
     "shelljs": "0.x.x",
+    "snyk-resolve": "^1.0.0",
     "strip-json-comments": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
snyk-resolve is required in the eslint interface file but is not in the package.json